### PR TITLE
Forgo mixin for now and format money via method

### DIFF
--- a/vue_dollar_3/vue_dollar_3/src/components/Navigation.vue
+++ b/vue_dollar_3/vue_dollar_3/src/components/Navigation.vue
@@ -21,10 +21,20 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 nav {
-  display: flex;
-  justify-content: space-evenly;
+  /* display: flex;
+  justify-content: space-evenly; */
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
 }
+
+img {
+  grid-column: 2;
+  margin: auto;
+}
+
 a {
   align-self: center;
+  font-size: revert;
+  font-size: x-large;
 }
 </style>

--- a/vue_dollar_3/vue_dollar_3/src/pages/transactions/create.vue
+++ b/vue_dollar_3/vue_dollar_3/src/pages/transactions/create.vue
@@ -79,11 +79,17 @@ export default {
     },
     validForm() {
       this.errors = [];
+      if (!this.form.description && !this.form.amount) {
+        this.errors.push('Description & Amount are required');
+        return false;
+      }
       if (!this.form.description) {
         this.errors.push('Description is required');
+        return false;
       }
       if (!this.form.amount) {
         this.errors.push('Amount is required');
+        return false;
       }
       return true;
     },

--- a/vue_dollar_3/vue_dollar_3/src/pages/transactions/index.vue
+++ b/vue_dollar_3/vue_dollar_3/src/pages/transactions/index.vue
@@ -3,15 +3,17 @@
     <h1>My Transactions</h1>
 
     <div
-      v-for="transaction in getTransactions"
-      :key="transaction"
+      v-for="(transaction, index) in getTransactions"
+      :key="index"
       class="transaction"
     >
       <div class="transactions-div">
         <div class="w-20">{{ transaction.type }}</div>
         <div>{{ transaction.description.substring(0, 30) }}</div>
       </div>
-      {{ transaction.amount }}
+      <div class="amount">
+        {{ formatMoney(transaction.amount) }}
+      </div>
     </div>
   </div>
 </template>
@@ -27,6 +29,18 @@ export default {
   },
   computed: {
     ...mapGetters(['getTransactions']),
+  },
+  methods: {
+    formatMoney(amount) {
+      let dollar = amount;
+      let sign = '$ ';
+
+      if (dollar < 0) {
+        sign = '- ';
+        dollar *= -1;
+      }
+      return sign + dollar.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+    },
   },
 };
 </script>
@@ -48,5 +62,9 @@ h1 {
 .transactions-div {
   display: flex;
   grid-template-columns: 1fr 1fr 1fr;
+  margin-top: 10%;
+}
+.amount {
+  margin-top: 10%;
 }
 </style>

--- a/vue_dollar_3/vue_dollar_3/src/store/index.js
+++ b/vue_dollar_3/vue_dollar_3/src/store/index.js
@@ -7,8 +7,8 @@ export default new Vuex.Store({
 
   state: {
     transactions: [
-      { type: 'debit', description: 'Something responsible', amount: 4500 },
-      { type: 'credit', description: 'Payroll', amount: 100000 },
+      { type: 'debit', description: 'Something responsible', amount: 378.93 },
+      { type: 'credit', description: 'Payroll', amount: 1278.32 },
     ],
   },
 


### PR DESCRIPTION
This commit adds the money formatting method in pages/transactions/index.vue. At this point the basic functionality for the site is done. Transactions can be added to the list and the user is redirected to the page listing all transactions.